### PR TITLE
Fix deserialisation of Woolworths SaleFinder catalogues

### DIFF
--- a/CatalogueScanner.SaleFinder/Dto/SaleFinder/SaleFinderCatalogue.cs
+++ b/CatalogueScanner.SaleFinder/Dto/SaleFinder/SaleFinderCatalogue.cs
@@ -69,7 +69,9 @@ namespace CatalogueScanner.SaleFinder.Dto.SaleFinder
 
     public partial class Item
     {
-        public string? VideoId { get; set; }
+        [JsonConverter(typeof(ExponentInt64Converter))]
+        public long? VideoId { get; set; }
+
         public Shape Shape { get; set; }
 
         [JsonInclude]


### PR DESCRIPTION
It seems that the "videoId" property can be a number, numeric string or empty string