### PR TITLE
Update GitHub Actions

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -2,8 +2,8 @@
   "version": 1,
   "isRoot": true,
   "tools": {
-    "poextractor": {
-      "version": "0.5.0",
+    "orchardcorecontrib.poextractor": {
+      "version": "1.0.0-preview",
       "commands": [
         "extractpo"
       ]

--- a/.github/actions/build-catalogue-scanner/action.yml
+++ b/.github/actions/build-catalogue-scanner/action.yml
@@ -15,13 +15,8 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Setup .NET 5
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 5.0.x
-
-    - name: Setup .NET 6
-      uses: actions/setup-dotnet@v1
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x
 

--- a/.github/actions/sanitise-artifact-name/action.yml
+++ b/.github/actions/sanitise-artifact-name/action.yml
@@ -34,4 +34,4 @@ runs:
         # - Forward slash /
 
         $sanitisedName = [regex]::Replace($env:ARTIFACT_NAME, "["":<>|*?`r`n\\/]", '-')
-        echo "::set-output name=sanitised-name::$sanitisedName"
+        echo "sanitised-name=$sanitisedName" >> $GITHUB_OUTPUT

--- a/.github/actions/sanitise-artifact-name/action.yml
+++ b/.github/actions/sanitise-artifact-name/action.yml
@@ -34,4 +34,4 @@ runs:
         # - Forward slash /
 
         $sanitisedName = [regex]::Replace($env:ARTIFACT_NAME, "["":<>|*?`r`n\\/]", '-')
-        echo "sanitised-name=$sanitisedName" >> $GITHUB_OUTPUT
+        echo "sanitised-name=$sanitisedName" > $env:GITHUB_OUTPUT

--- a/.github/workflows/build-and-deploy-production.yml
+++ b/.github/workflows/build-and-deploy-production.yml
@@ -13,7 +13,7 @@ jobs:
     uses: ./.github/workflows/deploy-functions-app.yml
     needs: build
     with:
-      environment: Production
+      environment: Production (Functions App)
       artifact-name: ${{ needs.build.outputs.functions-app-artifact-name }}
       output-path: ${{ needs.build.outputs.functions-app-output-path }}
       app-name: catalogue-scanner
@@ -26,7 +26,7 @@ jobs:
     uses: ./.github/workflows/deploy-configuration-ui.yml
     needs: build
     with:
-      environment: Production
+      environment: Production (Configuration UI)
       artifact-name: ${{ needs.build.outputs.configuration-ui-artifact-name }}
       output-path: ${{ needs.build.outputs.configuration-ui-output-path }}
       app-name: catalogue-scanner-configuration-ui

--- a/.github/workflows/build-and-deploy-test.yml
+++ b/.github/workflows/build-and-deploy-test.yml
@@ -13,7 +13,7 @@ jobs:
     uses: ./.github/workflows/deploy-functions-app.yml
     needs: build
     with:
-      environment: Test
+      environment: Test (Functions App)
       artifact-name: ${{ needs.build.outputs.functions-app-artifact-name }}
       output-path: ${{ needs.build.outputs.functions-app-output-path }}
       app-name: catalogue-scanner-test
@@ -26,7 +26,7 @@ jobs:
     uses: ./.github/workflows/deploy-configuration-ui.yml
     needs: build
     with:
-      environment: Test
+      environment: Test (Configuration UI)
       artifact-name: ${{ needs.build.outputs.configuration-ui-artifact-name }}
       output-path: ${{ needs.build.outputs.configuration-ui-output-path }}
       app-name: catalogue-scanner-configuration-ui-test

--- a/.github/workflows/build-application.yml
+++ b/.github/workflows/build-application.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build application
         uses: ./.github/actions/build-catalogue-scanner
@@ -74,13 +74,13 @@ jobs:
           name: ${{ format('CatalogueScanner.ConfigurationUI-{0}{1}', github.ref_name, env.SHA_SUFFIX) }}
 
       - name: Archive Functions App
-        uses: alehechka/upload-tartifact@v1
+        uses: Choonster/upload-tartifact@7f320c4284bb1a63685f5b5a748c20ec6d07fb98
         with:
           name: ${{ steps.sanitise-functions-app-artifact-name.outputs.sanitised-name }}
           path: ${{ env.FUNCTIONS_APP_OUTPUT_PATH }}
 
       - name: Archive Configuration UI
-        uses: alehechka/upload-tartifact@v1
+        uses: Choonster/upload-tartifact@7f320c4284bb1a63685f5b5a748c20ec6d07fb98
         with:
           name: ${{ steps.sanitise-configuration-ui-artifact-name.outputs.sanitised-name }}
           path: ${{ env.CONFIGURATION_UI_OUTPUT_PATH }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # We must fetch at least the immediate parents so that if this is
           # a pull request then we can checkout the head.

--- a/.github/workflows/deploy-configuration-ui.yml
+++ b/.github/workflows/deploy-configuration-ui.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Download Artifact
-        uses: alehechka/download-tartifact@v1
+        uses: Choonster/download-tartifact@162f0c1be0f868230472f2ea2b0be2273af4b062
         with:
           name: ${{ inputs.artifact-name }}
 

--- a/.github/workflows/deploy-functions-app.yml
+++ b/.github/workflows/deploy-functions-app.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Download Artifact
-        uses: alehechka/download-tartifact@v1
+        uses: Choonster/download-tartifact@162f0c1be0f868230472f2ea2b0be2273af4b062
         with:
           name: ${{ inputs.artifact-name }}
 


### PR DESCRIPTION
- Update to checkout@v3 and setup-dotnet@v3
- Switch upload-tartifact/download-tartifact to forks using checkout@v3
- Update PoExtractor tool to latest preview from OrchardCore
- Remove .NET 5 setup
- Change sanitise-artifact-name to use `$GITHUB_OUTPUT` instead of `::set-output`
- Use separate environments for each app