### PR TITLE
Fix Coles Online types

### DIFF
--- a/CatalogueScanner.ColesOnline/Dto/ColesOnline/BrowseResponse.cs
+++ b/CatalogueScanner.ColesOnline/Dto/ColesOnline/BrowseResponse.cs
@@ -61,8 +61,7 @@ namespace CatalogueScanner.ColesOnline.Dto.ColesOnline
     {
         public string? Id { get; set; }
 
-        [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
-        public long Value { get; set; }
+        public string? Value { get; set; }
     }
 
     public partial class CatalogGroupView

--- a/CatalogueScanner.ColesOnline/Dto/ColesOnline/BrowseResponse.cs
+++ b/CatalogueScanner.ColesOnline/Dto/ColesOnline/BrowseResponse.cs
@@ -263,6 +263,7 @@ namespace CatalogueScanner.ColesOnline.Dto.ColesOnline
         [JsonPropertyName("GROCERY")] Grocery,
         [JsonPropertyName("LIQUOR")] Liquor,
         [JsonPropertyName("MEAT")] Meat,
+        [JsonPropertyName("APPAREL")] Apparel,
     }
 
     [JsonConverter(typeof(JsonStringEnumMemberConverter))]


### PR DESCRIPTION
- Fix type of `AdditionalField.Value` property
  - Initial data only had numeric strings (e.g. `id` = `"roundel"`, `value` = `"3"`), current data has non-numeric strings (e.g. `id` = `"description"`, `value` = `"See what's hot! Specials change every week."`).
-  Add missing `TradeProfitCentre` value