### PR TITLE
Fix catalogue parsing errors

### DIFF
--- a/CatalogueScanner.ColesOnline/Dto/ColesOnline/NextData.cs
+++ b/CatalogueScanner.ColesOnline/Dto/ColesOnline/NextData.cs
@@ -26,7 +26,7 @@ namespace CatalogueScanner.ColesOnline.Dto.ColesOnline
 
     public class NextDataPageProps
     {
-        public long InitStoreId { get; set; }
+        public long? InitStoreId { get; set; }
         public Uri? AssetsUrl { get; set; }
         public NextDataPagePropsData? Data { get; set; }
         public object? Error { get; set; }

--- a/CatalogueScanner.SaleFinder/Functions/FillSaleFinderItemPrice/FillSaleFinderItemPrice.cs
+++ b/CatalogueScanner.SaleFinder/Functions/FillSaleFinderItemPrice/FillSaleFinderItemPrice.cs
@@ -16,7 +16,9 @@ namespace CatalogueScanner.SaleFinder.Functions
 {
     public class FillSaleFinderItemPrice
     {
-        private static readonly Regex MultiBuyNForRegex = new(@"(?:Any\s*)?(\d+)\s+for");
+        private static readonly Regex MultiBuyNForRegex = new(@"(?:Any\s*)?(\d+)\s+for", RegexOptions.IgnoreCase);
+        private const string AnyOfTheseText = "Any of these";
+        private const string NowText = "Now";
 
         private readonly SaleFinderService saleFinderService;
 
@@ -86,17 +88,20 @@ namespace CatalogueScanner.SaleFinder.Functions
                 price = decimal.Parse(priceDisplaySpan.InnerText, NumberStyles.Currency, input.CurrencyCulture);
             }
 
-            // The .sf-saleoptiondesc span is only present for multi-buy prices (e.g. 2 for $10)
+            // The .sf-saleoptiondesc span is only present for multi-buy prices (e.g. 2 for $10) or other promotional text, e.g. "Any of these"
             var saleOptionDescSpan = DescendantByNameAndClass(nowPriceSpan, "span", "sf-saleoptiondesc");
 
             if (saleOptionDescSpan is not null)
             {
                 var saleOptionDescText = saleOptionDescSpan.InnerText;
-                var multiBuyNForMatch = MultiBuyNForRegex.Match(saleOptionDescText);
 
-                if (multiBuyNForMatch.Success)
+                if (saleOptionDescText == AnyOfTheseText || saleOptionDescText == NowText)
                 {
-                    item.MultiBuyQuantity = ParseLong(multiBuyNForMatch.Groups[1].Value);
+                    item.Price = price;
+                }
+                else if (MultiBuyNForRegex.Match(saleOptionDescText) is { Success: true } match)
+                {
+                    item.MultiBuyQuantity = ParseLong(match.Groups[1].Value);
                     item.MultiBuyTotalPrice = price;
                 }
                 else

--- a/CatalogueScanner.SaleFinder/Functions/FillSaleFinderItemPrice/FillSaleFinderItemPrice.cs
+++ b/CatalogueScanner.SaleFinder/Functions/FillSaleFinderItemPrice/FillSaleFinderItemPrice.cs
@@ -88,7 +88,7 @@ namespace CatalogueScanner.SaleFinder.Functions
                 price = decimal.Parse(priceDisplaySpan.InnerText, NumberStyles.Currency, input.CurrencyCulture);
             }
 
-            // The .sf-saleoptiondesc span is only present for multi-buy prices (e.g. 2 for $10) or other promotional text, e.g. "Any of these"
+            // The .sf-saleoptiondesc span is only present for multi-buy prices (e.g. 2 for $10) or other promotional text (e.g. "Any of these")
             var saleOptionDescSpan = DescendantByNameAndClass(nowPriceSpan, "span", "sf-saleoptiondesc");
 
             if (saleOptionDescSpan is not null)

--- a/CatalogueScanner.SaleFinder/Functions/FillSaleFinderItemPrice/SampleData/item-tooltip-521911662-bigw-multi-uppercase.html
+++ b/CatalogueScanner.SaleFinder/Functions/FillSaleFinderItemPrice/SampleData/item-tooltip-521911662-bigw-multi-uppercase.html
@@ -1,0 +1,74 @@
+<div id="sf-item-tooltip" data-sku="1530703-sprfloral"
+    data-url="https://www.bigw.com.au/product/dymples-baby-organic-cotton-blend-floral-print-leggings-pink/p/1530703-sprfloral">
+    <div id="sf-item-tooltip-image-container">
+        <a id="sf-item-tooltip-image">
+            <img src="https://dduhxx0oznf63.cloudfront.net/images/products/330x330/521911662_724c91c5251de80.jpg" />
+            <div id="sf-zoomhint"></div>
+        </a>
+        <div id="sf-item-image-carousel">
+            <ul>
+                <li><a data-largeimage="https://dduhxx0oznf63.cloudfront.net/images/products/521911662_724c91c5251de80.jpg"
+                        data-imageurl="https://dduhxx0oznf63.cloudfront.net/images/products/330x330/521911662_724c91c5251de80.jpg"><img
+                            src="https://dduhxx0oznf63.cloudfront.net/images/products/60x60/521911662_724c91c5251de80.jpg" /></a>
+                </li>
+
+
+
+
+            </ul>
+            <div class="sf-clear"></div>
+        </div>
+    </div>
+    <div id="sf-item-tooltip-details-container">
+
+        <h1>Dymples Leggings Containing Organically Grown Cotton - Pink</h1>
+        <div class="sf-clear"></div>
+        <div class="sf-price-options">
+            <span class="sf-regoption">
+                <span class="sf-regoptiondesc">Save</span>
+                <span class="sf-regoptiontext"></span>
+                <span class="sf-regprice">$3</span>
+                <span class="sf-optionsuffix"></span>
+            </span>
+            <br />
+            <span class="sf-nowprice">
+                <span class="sf-saleoptiondesc">3 For</span>
+                <span class="sf-saleoptiontext"></span>
+                <span class="sf-pricedisplay">$12</span>
+                <span class="sf-optionsuffix"></span>
+            </span>
+            <br />
+            <span class="sf-regoption">
+                <span class="sf-regoptiondesc">Or</span>
+                <span class="sf-regoptiontext"></span>
+                <span class="sf-regprice">$5</span>
+                <span class="sf-optionsuffix">each</span>
+            </span>
+            <br />
+            </span>
+        </div>
+        <p>Sizes 000-2 <br><br>Promotional price only applies when a purchase is made of the selected range in the one
+            transaction. Otherwise the single price shown applies. &ldquo;Save&rdquo; is based on a purchase being made
+            of the specified number of items from the selected range.</p>
+        <hr class="small">
+        <div class="sf-item-actions" style="height:60px">
+            <a class="sf-buynow-button Button variant-primary"
+                href="https://www.bigw.com.au/product/dymples-baby-organic-cotton-blend-floral-print-leggings-pink/p/1530703-sprfloral"
+                target="_blank">Shop Now</a>
+        </div>
+        <hr class="small">
+        <div class="sf-clear"></div>
+    </div>
+    <div class="sf-clear"></div>
+</div>
+<div class="sf-clear"></div>
+<div style="display:none">
+    <div id="sf-item-tooltip-popup">
+        <div id="sf-item-tooltip-popup-container">
+            <img src="https://dduhxx0oznf63.cloudfront.net/images/products/521911662_724c91c5251de80.jpg" width="700"
+                height="700" /><br />
+            <a id="backtopopup" class="readbutton"
+                href="https://embed.salefinder.com.au/item/tooltip/521911662/">&laquo; Back</a>
+        </div>
+    </div>
+</div>

--- a/CatalogueScanner.SaleFinder/Functions/FillSaleFinderItemPrice/SampleData/item-tooltip-523121358-coles-now.html
+++ b/CatalogueScanner.SaleFinder/Functions/FillSaleFinderItemPrice/SampleData/item-tooltip-523121358-coles-now.html
@@ -1,0 +1,42 @@
+<div id="sf-item-tooltip">
+	<div id="sf-item-tooltip-image-container">
+		<a id="sf-item-tooltip-image" href="#sf-item-tooltip-popup"><img src="https://dduhxx0oznf63.cloudfront.net/images/products/300x300/523121358_86dc97582656b7e.jpg" width="300" height="300" alt="Southern Comfort"/></a><br />
+		<p role="presentation">Click image to zoom in</p>
+	</div>
+	<div id="sf-item-tooltip-details-container">
+		<div id="sf-item-tooltip-container" tabindex="0" aria-labelledby="sf-accessibility-message">
+			<span id="sf-accessibility-message" class="sf-accessibility-message">pop up box displayed&nbsp; product details Southern Comfort</span>
+			<h1>Southern Comfort</h1>
+						<p>Offers apply from 18/10/23 until 24/10/23 while stocks last. Specials not available through Liquorland George Street, World Square or Liquorland Broken Hill store. Prices may vary in regional areas. Some products and offers may not be available in all stores or Coles Liquor Supermarkets. Save statements are based on the lowest of the regular single selling price across our New South Wales Metro stores. All wine, sparkling and champagne bottles are 750mL unless otherwise stated. All spirits are 700mL unless otherwise stated. Not valid in conjunction with any other offer. Retail limits apply. Liquor and tobacco not sold to under 18&rsquo;s. Not all promotions available online. All liquor products are sold and supplied by Liquorland (Australia) Pty Ltd. To view our terms and conditions including licence numbers visit www.liquorland.com.au.<br><br>For more information regarding liquor licensing laws and licence numbers in your State or Territory visit https://shop.coles.com.au/a/national/content/orders-with-alcohol-and-tobacco</p>
+						<div class="sf-price-options">
+	<span class="sf-regoption">	<span class="sf-regoptiondesc">Was</span>	 <span class="sf-regoptiontext"></span> <span class="sf-regprice">$53.00</span> <span class="sf-optionsuffix"></span>	</span><br />	<span class="sf-nowprice">	<span class="sf-saleoptiondesc">Now</span>	 <span class="sf-saleoptiontext"></span> <span class="sf-pricedisplay">$42.00</span> <span class="sf-optionsuffix">each</span>	</span><br /></div>			<div class="sf-tooltip-saledates">Offers valid until Tuesday 24 October 2023</div>
+		</div>
+				<div class="rocket__shopping-list__limit"><span role="img" aria-label="warning" class="icon svg-warning-circle"></span><span>You have reached the limit of 100 items. Please ensure you have items of 100 or less to continue.</span></div>
+			<ul id="sf-product-varieties-list" data-itemid="523121358">
+							<li id="sf-sku-8331919P">
+					<div class="sf-variety-image-container"><img src="https://shop.coles.com.au/wcsstore/Coles-CAS/images/8/3/3/8331919-th.jpg" width="50" alt="Southern Comfort 700mL 1 Each" /></div>
+					<div class="sf-variety-name-container"><span>Southern Comfort 700mL 1 Each</span></div>
+					<div class="sf-variety-flag-container">
+						<div class="sf-variety-addtocart-flag"></div>
+					</div>
+					<div class="sf-variety-addtocart-container">
+						<div role="group" aria-label="Southern Comfort" style="position:relative">
+							<input type="number" title="Add Quantity for Southern Comfort" name="quantity" class="quantity-input" min="1" max="99" maxlength="3" value="1">
+							<button type="submit" class="button button--primary add-to-trolley-button" data-itemname="Southern Comfort 700mL 1 Each" data-sku="8331919P" data-itemprice="42.00" aria-label="Add Southern Comfort to shopping list">Add</button>
+		</div>
+					</div>
+				</li>
+						</ul>
+			<div style="height:20px"><a id="sf-scroll-variety-btn"><span class="sf-arrowdown"></span><span>More products</span></a></div>
+	</div>
+	<div class="sf-clear">&nbsp;</div>
+</div>
+<div style="display:none">
+	<div id="sf-item-tooltip-popup">
+		<div style="padding:10px">
+			<a id="backtopopup" href="https://embed.salefinder.com.au/item/tooltip/523121358/">&lt; Back</a>
+			<img src="https://dduhxx0oznf63.cloudfront.net/images/products/523121358_86dc97582656b7e.jpg" width="166" height="569" />
+		</div>
+	</div>
+</div>
+

--- a/CatalogueScanner.SaleFinder/Functions/FillSaleFinderItemPrice/SampleData/item-tooltip-523121366-coles-any-of-these.html
+++ b/CatalogueScanner.SaleFinder/Functions/FillSaleFinderItemPrice/SampleData/item-tooltip-523121366-coles-any-of-these.html
@@ -1,0 +1,94 @@
+<div id="sf-item-tooltip">
+    <div id="sf-item-tooltip-image-container">
+        <a id="sf-item-tooltip-image" href="#sf-item-tooltip-popup"><img
+                src="https://dduhxx0oznf63.cloudfront.net/images/products/300x300/523121366_c6db1ae0d6ee27c.jpg"
+                width="300" height="300"
+                alt="Squealing Pig Marlborough Sauvignon Blanc or Squealing Pig Prosecco NV" /></a><br />
+        <p role="presentation">Click image to zoom in</p>
+    </div>
+    <div id="sf-item-tooltip-details-container">
+        <div id="sf-item-tooltip-container" tabindex="0" aria-labelledby="sf-accessibility-message">
+            <span id="sf-accessibility-message" class="sf-accessibility-message">pop up box displayed&nbsp; product
+                details Squealing Pig Marlborough Sauvignon Blanc or Squealing Pig Prosecco NV</span>
+            <h1>Squealing Pig Marlborough Sauvignon Blanc or Squealing Pig Prosecco NV</h1>
+            <p>Offers apply from 18/10/23 until 24/10/23 while stocks last. Specials not available through Liquorland
+                George Street, World Square or Liquorland Broken Hill store. Prices may vary in regional areas. Some
+                products and offers may not be available in all stores or Coles Liquor Supermarkets. Save statements are
+                based on the lowest of the regular single selling price across our New South Wales Metro stores. All
+                wine, sparkling and champagne bottles are 750mL unless otherwise stated. All spirits are 700mL unless
+                otherwise stated. Not valid in conjunction with any other offer. Retail limits apply. Liquor and tobacco
+                not sold to under 18&rsquo;s. Not all promotions available online. All liquor products are sold and
+                supplied by Liquorland (Australia) Pty Ltd. To view our terms and conditions including licence numbers
+                visit www.liquorland.com.au.<br><br>For more information regarding liquor licensing laws and licence
+                numbers in your State or Territory visit
+                https://shop.coles.com.au/a/national/content/orders-with-alcohol-and-tobacco</p>
+            <div class="sf-price-options">
+                </span> <span class="sf-nowprice"> <span class="sf-saleoptiondesc">Any of these</span> <span
+                        class="sf-saleoptiontext"></span> <span class="sf-pricedisplay">$16.00</span> <span
+                        class="sf-optionsuffix">each</span> </span><br /></div>
+            <div class="sf-tooltip-saledates">Offers valid until Tuesday 24 October 2023</div>
+        </div>
+        <div class="rocket__shopping-list__limit"><span role="img" aria-label="warning"
+                class="icon svg-warning-circle"></span><span>You have reached the limit of 100 items. Please ensure you
+                have items of 100 or less to continue.</span></div>
+        <ul id="sf-product-varieties-list" data-itemid="523121366">
+            <li id="sf-sku-9948878P">
+                <div class="sf-variety-image-container"><img
+                        src="https://shop.coles.com.au/wcsstore/Coles-CAS/images/9/9/4/9948878-th.jpg" width="50"
+                        alt="Squealing Pig Marlborough Sauvignon Blanc 750mL 1 Each" /></div>
+                <div class="sf-variety-name-container"><span>Squealing Pig Marlborough Sauvignon Blanc 750mL 1
+                        Each</span></div>
+                <div class="sf-variety-flag-container">
+                    <div class="sf-variety-addtocart-flag"></div>
+                </div>
+                <div class="sf-variety-addtocart-container">
+                    <div role="group"
+                        aria-label="Squealing Pig Marlborough Sauvignon Blanc or Squealing Pig Prosecco NV"
+                        style="position:relative">
+                        <input type="number"
+                            title="Add Quantity for Squealing Pig Marlborough Sauvignon Blanc or Squealing Pig Prosecco NV"
+                            name="quantity" class="quantity-input" min="1" max="99" maxlength="3" value="1">
+                        <button type="submit" class="button button--primary add-to-trolley-button"
+                            data-itemname="Squealing Pig Marlborough Sauvignon Blanc 750mL 1 Each" data-sku="9948878P"
+                            data-itemprice="16.00"
+                            aria-label="Add Squealing Pig Marlborough Sauvignon Blanc or Squealing Pig Prosecco NV to shopping list">Add</button>
+                    </div>
+                </div>
+            </li>
+            <li id="sf-sku-3607659P">
+                <div class="sf-variety-image-container"><img
+                        src="https://shop.coles.com.au/wcsstore/Coles-CAS/images/3/6/0/3607659-th.jpg" width="50"
+                        alt="Squealing Pig Prosecco NV 750mL 1 Each" /></div>
+                <div class="sf-variety-name-container"><span>Squealing Pig Prosecco NV 750mL 1 Each</span></div>
+                <div class="sf-variety-flag-container">
+                    <div class="sf-variety-addtocart-flag"></div>
+                </div>
+                <div class="sf-variety-addtocart-container">
+                    <div role="group"
+                        aria-label="Squealing Pig Marlborough Sauvignon Blanc or Squealing Pig Prosecco NV"
+                        style="position:relative">
+                        <input type="number"
+                            title="Add Quantity for Squealing Pig Marlborough Sauvignon Blanc or Squealing Pig Prosecco NV"
+                            name="quantity" class="quantity-input" min="1" max="99" maxlength="3" value="1">
+                        <button type="submit" class="button button--primary add-to-trolley-button"
+                            data-itemname="Squealing Pig Prosecco NV 750mL 1 Each" data-sku="3607659P"
+                            data-itemprice="16.00"
+                            aria-label="Add Squealing Pig Marlborough Sauvignon Blanc or Squealing Pig Prosecco NV to shopping list">Add</button>
+                    </div>
+                </div>
+            </li>
+        </ul>
+        <div style="height:20px"><a id="sf-scroll-variety-btn"><span class="sf-arrowdown"></span><span>More
+                    products</span></a></div>
+    </div>
+    <div class="sf-clear">&nbsp;</div>
+</div>
+<div style="display:none">
+    <div id="sf-item-tooltip-popup">
+        <div style="padding:10px">
+            <a id="backtopopup" href="https://embed.salefinder.com.au/item/tooltip/523121366/">&lt; Back</a>
+            <img src="https://dduhxx0oznf63.cloudfront.net/images/products/523121366_c6db1ae0d6ee27c.jpg" width="326"
+                height="609" />
+        </div>
+    </div>
+</div>

--- a/CatalogueScanner.WoolworthsOnline/Dto/WoolworthsOnline/BrowseCategoryResponse.cs
+++ b/CatalogueScanner.WoolworthsOnline/Dto/WoolworthsOnline/BrowseCategoryResponse.cs
@@ -268,6 +268,7 @@ namespace CatalogueScanner.WoolworthsOnline.Dto.WoolworthsOnline
     {
         Html,
         None,
+        Image,
     }
 
     [JsonConverter(typeof(JsonStringEnumMemberConverter))]


### PR DESCRIPTION
- Make `NextDataPageProps.InitStoreId` nullable for Coles Online
- Add missing `TagType.Image` value for Woolworths Online
- Add support for additional promotional text for Sale Finder