### PR TITLE
Include cookies in Woolworths Online requests to avoid errors

### DIFF
--- a/CatalogueScanner.DefaultHost/packages.lock.json
+++ b/CatalogueScanner.DefaultHost/packages.lock.json
@@ -1197,7 +1197,8 @@
       "cataloguescanner.woolworthsonline": {
         "type": "Project",
         "dependencies": {
-          "CatalogueScanner.Core": "[1.0.0, )"
+          "CatalogueScanner.Core": "[1.0.0, )",
+          "Microsoft.Net.Http.Headers": "[8.0.0, )"
         }
       }
     }

--- a/CatalogueScanner.WoolworthsOnline/CatalogueScanner.WoolworthsOnline.csproj
+++ b/CatalogueScanner.WoolworthsOnline/CatalogueScanner.WoolworthsOnline.csproj
@@ -19,4 +19,8 @@
 		</Content>
 	</ItemGroup>
 
+	<ItemGroup>
+	  <PackageReference Include="Microsoft.Net.Http.Headers" Version="8.0.0" />
+	</ItemGroup>
+
 </Project>

--- a/CatalogueScanner.WoolworthsOnline/Dto/FunctionInput/DownloadWoolworthsOnlineSpecialsPageInput.cs
+++ b/CatalogueScanner.WoolworthsOnline/Dto/FunctionInput/DownloadWoolworthsOnlineSpecialsPageInput.cs
@@ -1,7 +1,5 @@
-﻿namespace CatalogueScanner.WoolworthsOnline.Dto.FunctionInput;
+﻿using System.Net;
 
-public class DownloadWoolworthsOnlineSpecialsPageInput
-{
-    public string? CategoryId { get; set; }
-    public int PageNumber { get; set; }
-}
+namespace CatalogueScanner.WoolworthsOnline.Dto.FunctionInput;
+
+public record DownloadWoolworthsOnlineSpecialsPageInput(string? CategoryId, int PageNumber, CookieCollection Cookies);

--- a/CatalogueScanner.WoolworthsOnline/Dto/FunctionInput/GetWoolworthsOnlineSpecialsPageCountInput.cs
+++ b/CatalogueScanner.WoolworthsOnline/Dto/FunctionInput/GetWoolworthsOnlineSpecialsPageCountInput.cs
@@ -1,0 +1,5 @@
+﻿using System.Net;
+
+namespace CatalogueScanner.WoolworthsOnline.Dto.FunctionInput;
+
+public record GetWoolworthsOnlineSpecialsPageCountInput(string? CategoryId, CookieCollection Cookies);

--- a/CatalogueScanner.WoolworthsOnline/Functions/DownloadWoolworthsOnlineSpecialsPage/DownloadWoolworthsOnlineSpecialsPage.cs
+++ b/CatalogueScanner.WoolworthsOnline/Functions/DownloadWoolworthsOnlineSpecialsPage/DownloadWoolworthsOnlineSpecialsPage.cs
@@ -26,7 +26,7 @@ public class DownloadWoolworthsOnlineSpecialsPage(WoolworthsOnlineService woolwo
             CategoryId = input.CategoryId,
             PageNumber = input.PageNumber,
             PageSize = WoolworthsOnlineService.MaxBrowseCategoryDataPageSize,
-        }, cancellationToken).ConfigureAwait(false);
+        }, input.Cookies, cancellationToken).ConfigureAwait(false);
 
         var items = response.Bundles
            .SelectMany(bundle =>

--- a/CatalogueScanner.WoolworthsOnline/Functions/GetWoolworthsOnlineCookies/GetWoolworthsOnlineCookies.cs
+++ b/CatalogueScanner.WoolworthsOnline/Functions/GetWoolworthsOnlineCookies/GetWoolworthsOnlineCookies.cs
@@ -1,0 +1,23 @@
+﻿using CatalogueScanner.WoolworthsOnline.Service;
+using Microsoft.Azure.Functions.Worker;
+using System.Net;
+
+namespace CatalogueScanner.WoolworthsOnline.Functions;
+
+public class GetWoolworthsOnlineCookies(WoolworthsOnlineService woolworthsOnlineService)
+{
+    private readonly WoolworthsOnlineService woolworthsOnlineService = woolworthsOnlineService;
+
+    [Function(WoolworthsOnlineFunctionNames.GetWoolworthsOnlineCookies)]
+    public async Task<CookieCollection> Run(
+        CancellationToken cancellationToken,
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Required by Azure Functions")]
+        [ActivityTrigger]
+        object? input = null
+    )
+    {
+        var cookies = await woolworthsOnlineService.GetCookiesAsync(cancellationToken).ConfigureAwait(false);
+
+        return cookies;
+    }
+}

--- a/CatalogueScanner.WoolworthsOnline/Functions/GetWoolworthsOnlineSpecialsCategories/GetWoolworthsOnlineSpecialsCategories.cs
+++ b/CatalogueScanner.WoolworthsOnline/Functions/GetWoolworthsOnlineSpecialsCategories/GetWoolworthsOnlineSpecialsCategories.cs
@@ -2,6 +2,7 @@
 using CatalogueScanner.WoolworthsOnline.Dto.WoolworthsOnline;
 using CatalogueScanner.WoolworthsOnline.Service;
 using Microsoft.Azure.Functions.Worker;
+using System.Net;
 
 namespace CatalogueScanner.WoolworthsOnline.Functions;
 
@@ -11,13 +12,12 @@ public class GetWoolworthsOnlineSpecialsCategories(WoolworthsOnlineService woolw
 
     [Function(WoolworthsOnlineFunctionNames.GetWoolworthsOnlineSpecialsCategories)]
     public async Task<IEnumerable<WoolworthsOnlineCategory>> Run(
-        CancellationToken cancellationToken,
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Required by Azure Functions")]
         [ActivityTrigger]
-        object? input = null
+        CookieCollection cookies,
+        CancellationToken cancellationToken
     )
     {
-        var response = await woolworthsOnlineService.GetPiesCategoriesWithSpecialsAsync(cancellationToken).ConfigureAwait(false);
+        var response = await woolworthsOnlineService.GetPiesCategoriesWithSpecialsAsync(cookies, cancellationToken).ConfigureAwait(false);
 
         var specialsCategories = new List<WoolworthsOnlineCategory>();
 

--- a/CatalogueScanner.WoolworthsOnline/Functions/GetWoolworthsOnlineSpecialsPageCount/GetWoolworthsOnlineSpecialsPageCount.cs
+++ b/CatalogueScanner.WoolworthsOnline/Functions/GetWoolworthsOnlineSpecialsPageCount/GetWoolworthsOnlineSpecialsPageCount.cs
@@ -1,3 +1,4 @@
+using CatalogueScanner.WoolworthsOnline.Dto.FunctionInput;
 using CatalogueScanner.WoolworthsOnline.Service;
 using Microsoft.Azure.Functions.Worker;
 
@@ -8,18 +9,21 @@ public class GetWoolworthsOnlineSpecialsPageCount(WoolworthsOnlineService woolwo
     private readonly WoolworthsOnlineService woolworthsOnlineService = woolworthsOnlineService;
 
     [Function(WoolworthsOnlineFunctionNames.GetWoolworthsOnlineSpecialsPageCount)]
-    public async Task<int> Run([ActivityTrigger] string categoryId, CancellationToken cancellationToken)
+    public async Task<int> Run([ActivityTrigger] GetWoolworthsOnlineSpecialsPageCountInput input, CancellationToken cancellationToken)
     {
         #region null checks
-        if (string.IsNullOrEmpty(categoryId))
+        ArgumentNullException.ThrowIfNull(input);
+
+        if (string.IsNullOrEmpty(input.CategoryId))
         {
-            throw new ArgumentException($"'{nameof(categoryId)}' cannot be null or empty.", nameof(categoryId));
+            throw new ArgumentException($"'{nameof(input)}.{nameof(input.CategoryId)}' cannot be null or empty.", nameof(input));
         }
         #endregion
 
         return await woolworthsOnlineService.GetCategoryPageCountAsync(
-            categoryId,
+            input.CategoryId,
             WoolworthsOnlineService.MaxBrowseCategoryDataPageSize,
+            input.Cookies,
             cancellationToken
         ).ConfigureAwait(false);
     }

--- a/CatalogueScanner.WoolworthsOnline/Service/WoolworthsOnlineService.cs
+++ b/CatalogueScanner.WoolworthsOnline/Service/WoolworthsOnlineService.cs
@@ -1,6 +1,8 @@
 ﻿using CatalogueScanner.Core.Http;
 using CatalogueScanner.Core.Utility;
 using CatalogueScanner.WoolworthsOnline.Dto.WoolworthsOnline;
+using Microsoft.Net.Http.Headers;
+using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json.Serialization.Metadata;
 
@@ -17,6 +19,8 @@ public class WoolworthsOnlineService(HttpClient httpClient)
 
     private readonly HttpClient httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
 
+    private Uri BaseAddress => httpClient.BaseAddress ?? throw new InvalidOperationException("httpClient.BaseAddress is null");
+
     /// <summary>
     /// The time of week when Coles Online changes its specials.
     /// </summary>
@@ -24,18 +28,40 @@ public class WoolworthsOnlineService(HttpClient httpClient)
 
     public static Uri ProductUrlTemplate => new($"{WoolworthsBaseUrl}/shop/productdetails/[stockCode]");
 
+    public async Task<CookieCollection> GetCookiesAsync(CancellationToken cancellationToken = default)
+    {
+        var url = BaseAddress;
 
-    public async Task<GetPiesCategoriesResponse> GetPiesCategoriesWithSpecialsAsync(CancellationToken cancellationToken = default)
+        var response = await httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false)
+            ?? throw new InvalidOperationException("Root response is null");
+
+        if (!response.Headers.TryGetValues(HeaderNames.SetCookie, out var cookieHeaders))
+        {
+            return [];
+        }
+
+        var cookies = new CookieContainer();
+
+        foreach (var header in cookieHeaders)
+        {
+            cookies.SetCookies(url, header);
+        }
+
+        return cookies.GetAllCookies();
+    }
+
+    public async Task<GetPiesCategoriesResponse> GetPiesCategoriesWithSpecialsAsync(CookieCollection cookies, CancellationToken cancellationToken = default)
     {
         var response = await GetAsync(
             "PiesCategoriesWithSpecials",
             WoolworthsOnlineSerializerContext.Default.GetPiesCategoriesResponse,
+            cookies,
             cancellationToken
         ).ConfigureAwait(false) ?? throw new InvalidOperationException("PiesCategoriesWithSpecials response is null");
         return response;
     }
 
-    public async Task<BrowseCategoryResponse> GetBrowseCategoryDataAsync(BrowseCategoryRequest request, CancellationToken cancellationToken = default)
+    public async Task<BrowseCategoryResponse> GetBrowseCategoryDataAsync(BrowseCategoryRequest request, CookieCollection cookies, CancellationToken cancellationToken = default)
     {
         #region null checks
         ArgumentNullException.ThrowIfNull(request);
@@ -46,6 +72,7 @@ public class WoolworthsOnlineService(HttpClient httpClient)
             request,
             WoolworthsOnlineSerializerContext.Default.BrowseCategoryRequest,
             WoolworthsOnlineSerializerContext.Default.BrowseCategoryResponse,
+            cookies,
             cancellationToken
         ).ConfigureAwait(false) ?? throw new InvalidOperationException("Browse Category response is null");
         if (!response.Success)
@@ -56,34 +83,55 @@ public class WoolworthsOnlineService(HttpClient httpClient)
         return response;
     }
 
-    public async Task<int> GetCategoryPageCountAsync(string categoryId, int pageSize, CancellationToken cancellationToken = default)
+    public async Task<int> GetCategoryPageCountAsync(string categoryId, int pageSize, CookieCollection cookies, CancellationToken cancellationToken = default)
     {
         // Ignore pageSize for this request as we don't actually want any data
         var response = await GetBrowseCategoryDataAsync(new BrowseCategoryRequest
         {
             CategoryId = categoryId,
             PageNumber = 1,
-            PageSize = 0,
-        }, cancellationToken).ConfigureAwait(false);
+            PageSize = 1,
+        }, cookies, cancellationToken).ConfigureAwait(false);
 
         return (int)(response.TotalRecordCount / pageSize + 1);
     }
 
-    private async Task<TResponse?> GetAsync<TResponse>(string path, JsonTypeInfo<TResponse> responseTypeInfo, CancellationToken cancellationToken)
+    private async Task<TResponse?> GetAsync<TResponse>(string path, JsonTypeInfo<TResponse> responseTypeInfo, CookieCollection cookies, CancellationToken cancellationToken)
     {
-        var response = await httpClient.GetAsync(new Uri(path, UriKind.Relative), cancellationToken).ConfigureAwait(false);
+        using var requestMessage = new HttpRequestMessage(HttpMethod.Get, new Uri(path, UriKind.Relative));
+
+        AddCookieHeader(requestMessage, cookies);
+
+        var response = await httpClient.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
 
         await response.EnsureSuccessStatusCodeDetailedAsync().ConfigureAwait(false);
 
         return await response.Content.ReadFromJsonAsync(responseTypeInfo, cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task<TResponse?> PostAsync<TRequest, TResponse>(string path, TRequest request, JsonTypeInfo<TRequest> requestTypeInfo, JsonTypeInfo<TResponse> responseTypeInfo, CancellationToken cancellationToken)
+    private async Task<TResponse?> PostAsync<TRequest, TResponse>(string path, TRequest request, JsonTypeInfo<TRequest> requestTypeInfo, JsonTypeInfo<TResponse> responseTypeInfo, CookieCollection cookies, CancellationToken cancellationToken)
     {
-        var response = await httpClient.PostAsJsonAsync(new Uri(path, UriKind.Relative), request, requestTypeInfo, cancellationToken).ConfigureAwait(false);
+        using var requestMessage = new HttpRequestMessage(HttpMethod.Post, new Uri(path, UriKind.Relative))
+        {
+            Content = JsonContent.Create(request, requestTypeInfo),
+        };
+
+        AddCookieHeader(requestMessage, cookies);
+
+        var response = await httpClient.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
 
         await response.EnsureSuccessStatusCodeDetailedAsync().ConfigureAwait(false);
 
         return await response.Content.ReadFromJsonAsync(responseTypeInfo, cancellationToken).ConfigureAwait(false);
+    }
+
+    private void AddCookieHeader(HttpRequestMessage requestMessage, CookieCollection cookies)
+    {
+        var cookieContainer = new CookieContainer();
+        cookieContainer.Add(cookies);
+
+        var cookieHeader = cookieContainer.GetCookieHeader(BaseAddress);
+
+        requestMessage.Headers.Add(HeaderNames.Cookie, cookieHeader);
     }
 }

--- a/CatalogueScanner.WoolworthsOnline/WoolworthsOnlineFunctionNames.cs
+++ b/CatalogueScanner.WoolworthsOnline/WoolworthsOnlineFunctionNames.cs
@@ -18,6 +18,11 @@ public static class WoolworthsOnlineFunctionNames
     public const string GetWoolworthsOnlineSpecialsDates = "GetWoolworthsOnlineSpecialsDates";
 
     /// <summary>
+    /// The name of the <see cref="Functions.GetWoolworthsOnlineCookies"/> activity function.
+    /// </summary>
+    public const string GetWoolworthsOnlineCookies = "GetWoolworthsOnlineCookies";
+
+    /// <summary>
     /// The name of the <see cref="Functions.GetWoolworthsOnlineSpecialsCategories"/> activity function.
     /// </summary>
     public const string GetWoolworthsOnlineSpecialsCategories = "GetWoolworthsOnlineSpecialsCategories";

--- a/CatalogueScanner.WoolworthsOnline/packages.lock.json
+++ b/CatalogueScanner.WoolworthsOnline/packages.lock.json
@@ -2,6 +2,15 @@
   "version": 1,
   "dependencies": {
     "net8.0": {
+      "Microsoft.Net.Http.Headers": {
+        "type": "Direct",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "YlHqL8oWBX3H1LmdKUOxEMW8cVD8nUACEnE2Fu3Ze4k7mYf8yJ1o/uLqoequQV0GDupXyCBEzYhn7Zxdz7pqYQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
       "Azure.Core": {
         "type": "Transitive",
         "resolved": "1.35.0",


### PR DESCRIPTION
Requests to `browse/category` were being blocked by Akamai Bot Manager without these cookies.

Fixes #69.